### PR TITLE
docs: GENDA Advent Calendar 2025 1日目の記事を追加 (#19)

### DIFF
--- a/articles/2025-12-01-shell-script-claude-code.md
+++ b/articles/2025-12-01-shell-script-claude-code.md
@@ -30,6 +30,10 @@ https://qiita.com/advent-calendar/2025/genda
 これらのツールは対話的に使うだけでなく、シェルスクリプトに組み込んで自動化に活用することもできます。
 本記事では私が日常的に使っているシェルスクリプトに Claude Code を導入した実践例を紹介します。
 
+:::message
+本記事の内容は 2025年12月時点での検証結果に基づいています。
+:::
+
 ## 2. 対象読者
 
 - シェルスクリプトに抵抗がない方
@@ -39,7 +43,7 @@ https://qiita.com/advent-calendar/2025/genda
 
 各 AI CLI ツールには、プロンプトを渡して結果を受け取る非対話モードが用意されています。
 
-### 3.1. 各ツールのコマンド (2025/12/01 時点)
+### 3.1. 各ツールのコマンド
 
 | ツール             | コマンド例                |
 | ---                | ---                       |
@@ -67,6 +71,8 @@ Claude Code だけが余計な出力なしで純粋な結果のみを返しま�
 ## 4. 題材スクリプトの紹介
 
 私が日常的に使っている `issue-worktree-create` というスクリプトを題材にします。
+
+以下は執筆時点のバージョンのスクリプトです。
 
 https://github.com/i9wa4/dotfiles/blob/f92d338fb8e21ba915df1ee077d53eafafa1a118/bin/issue-worktree-create
 
@@ -174,15 +180,15 @@ Claude Code の非対話モードはAIに安定した出力を期待できる場
 ### 6.1. コミットメッセージの生成
 
 ```bash
-commit_msg=$(git diff --staged | claude -p "以下の差分から適切なコミットメッセージを1行で生成してください。Conventional Commits 形式で。出力はメッセージのみ。")
+commit_msg=$(GIT_PAGER=cat git diff --staged --no-color | claude -p "以下の差分から適切なコミットメッセージを1行で生成してください。Conventional Commits 形式で。出力はメッセージのみ。")
 git commit -m "$commit_msg"
 ```
 
 ### 6.2. ファイル名のリネーム
 
 ```bash
-new_name=$(claude -p "以下のファイル名を英語の kebab-case に変換してください。出力はファイル名のみ。: $old_name")
-mv "$old_name" "$new_name"
+new_name=$(claude -p "以下のファイル名を英語の kebab-case に変換してください。出力はファイル名のみ。: ${old_name}")
+mv "${old_name}" "${new_name}"
 ```
 
 ### 6.3. ログの要約


### PR DESCRIPTION
シェルスクリプト × Claude Code: 日常スクリプトへの導入実践

## 概要

GENDA Advent Calendar 2025 1日目の記事として、シェルスクリプトに Claude Code を組み込む実践例を紹介する記事を作成した。

## 背景

- GENDA Advent Calendar 2025 の 1日目 (2025-12-01) 記事として執筆
- dotfiles の issue-worktree-create スクリプトを題材に、AI CLI ツールの活用方法を解説

## 変更内容

- 記事ファイル `articles/2025-12-01-shell-script-claude-code.md` を新規作成
- 8セクション構成: はじめに、対象読者、AI CLI ツールの非対話モード、題材スクリプト紹介、Claude Code の組み込み方法、応用アイデア、おわりに、宣伝

## 技術詳細

- AI CLI ツール (Claude Code, Gemini CLI, Copilot CLI, Codex CLI) の比較を実施
- Claude Code の `--print` オプションのみが余計な出力なしで純粋な結果を返すことを強調
- シェルスクリプトで `$()` を使って結果を変数に取り込む用途での優位性を解説
- プロンプト設計のポイント (出力形式の明確化、制約条件の箇条書き、入力情報の構造化) を記載
- rumdl の MD034 ルールによる URL の `<>` 囲みを回避するため `<!-- markdownlint-disable MD034 -->` コメントを使用

## 動作確認

- rumdl fmt で Markdown フォーマット確認済み (MD013 行長超過のみ残存、既存記事と同等)
- Zenn のリンクプレビュー用に bare URL を維持

## 関連 URL

- https://github.com/i9wa4/zenn-i9wa4/issues/19
- https://qiita.com/advent-calendar/2025/genda
- https://github.com/i9wa4/dotfiles/blob/main/bin/issue-worktree-create